### PR TITLE
Change req.url -> req.original. It's very important for nested request handlers

### DIFF
--- a/server/render.js
+++ b/server/render.js
@@ -13,7 +13,7 @@ var path = require('path'),
 function render(req, res, data, context) {
     var query = req.query,
         user = req.user,
-        cacheKey = req.url + (context ? JSON.stringify(context) : '') + (user ? JSON.stringify(user) : ''),
+        cacheKey = req.originalUrl + (context ? JSON.stringify(context) : '') + (user ? JSON.stringify(user) : ''),
         cached = cache[cacheKey];
 
     if (useCache && cached && (new Date() - cached.timestamp < cacheTTL)) {


### PR DESCRIPTION
If you are use some nested request handlers, for example:
```javascript
var Router = require('express').Router;
var router = new Router();
var anotherRouter = new Router();

router.get('/', reqHandler);
anotherRouter.get('/', anotherReqHandler);

app
    .use(router)
    .use(anotherRouter)
```
req.url will be show relative url in this nested route handlers. So we must use req.originalUrl which always show full request url.